### PR TITLE
Disable build indices

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,11 +1,13 @@
-import { dev } from '$app/environment'
+// import { dev } from '$app/environment'
 import { v4 as uuid } from '@lukeed/uuid';
 import type { Handle } from '@sveltejs/kit';
-import { buildIndices } from '$services/algolia'
 
-if (!dev) {
-  buildIndices()
-}
+// We only need to build at the time of merging...
+// import { buildIndices } from '$services/algolia'
+//
+// if (!dev) {
+//   buildIndices()
+// }
 
 export const handle = (async ({ event, resolve }) => {
   const response = await resolve(event)


### PR DESCRIPTION
Occasionally get `500`s.

Not sure why. I'll need to look into it.
I suspect it is due to the nature of vercel serverless function deployments and this bit of code i'm temporarily removing.

https://vercel.com/jamesz96/blog/96kJF8ikr6wiuLqq9moW2tEiwR2f/logs?timeline=absolute&levels=error&page=1&startDate=1689889213976&endDate=1689892813976&selectedLogId=1689891969708196970806300000&selectedLogTimestamp=1689891969708&forceEndDate=1689892099424